### PR TITLE
[NO ISSUE] ビルド設定とGitHub Pagesデプロイ用のベースURLを修正

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
+    "noEmit": true,
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
       '@': path.resolve(__dirname, './src'),
     },
   },
-  base: '/hit-and-blow/',
+  base: '/hit-and-blow-game/',
   build: {
     outDir: 'dist',
     sourcemap: true,


### PR DESCRIPTION
## 関連 Issue

closes #

## 変更概要

- `tsconfig.json` に `noEmit: true` を追加し、`tsc` が `src/` ディレクトリに JavaScript ファイルを出力しないようにしました
- `vite.config.ts` の `base` パスを `/hit-and-blow/` から `/hit-and-blow-game/` に修正し、GitHub Pages のリポジトリパスと一致させました

## 変更種別

- [x] バグ修正
- [ ] 機能追加
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] その他

## 動作確認

- [x] ローカルで動作確認済み
- [x] 既存機能に影響がないことを確認済み

## レビュー観点

### 修正の背景
1. `tsc` が `src/` ディレクトリにコンパイル済みの `.js` ファイルを出力していたため、ビルドプロセスが汚染されていました
2. GitHub Pages のベース URL が実際のリポジトリパス (`hit-and-blow-game`) と異なっていため、アセットが読み込めていませんでした

### 修正内容
- `tsconfig.json` に `"noEmit": true` を設定して、`tsc` は型チェックのみを実行するようにしました
- `vite.config.ts` の `base` を `/hit-and-blow-game/` に修正し、生成される `index.html` のアセットパスが正しくなるようにしました

### ビルド結果
- `pnpm build` 実行後、`dist/index.html` のスクリプト src が `/hit-and-blow-game/assets/...` となり、正しいパスで読み込まれるようになりました
- `src/` ディレクトリに `.js` ファイルが出力されなくなりました