### PR TITLE
[NO ISSUE] VITE_BASE_URL を CI ビルド環境変数に追加

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,13 +26,14 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
         env:
-          VITE_BASE_URL: ${{ vars.VITE_BASE_URL }}
+          VITE_BASE_URL: ${{ secrets.VITE_BASE_URL }}
           VITE_LIFF_ID: ${{ secrets.VITE_LIFF_ID }}
           VITE_ADSENSE_CLIENT_ID: ${{ secrets.VITE_ADSENSE_CLIENT_ID }}
           VITE_ADSENSE_SLOT_ID: ${{ secrets.VITE_ADSENSE_SLOT_ID }}
+      # public/404.html 内の __VITE_BASE_URL__ プレースホルダーを実際の値に置換
       - run: sed -i "s|__VITE_BASE_URL__|${VITE_BASE_URL}|g" dist/404.html
         env:
-          VITE_BASE_URL: ${{ vars.VITE_BASE_URL }}
+          VITE_BASE_URL: ${{ secrets.VITE_BASE_URL }}
       - uses: actions/upload-pages-artifact@v3
         with:
           path: dist

--- a/public/404.html
+++ b/public/404.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <script>
       sessionStorage.setItem('redirectPath', location.pathname);
+      // __VITE_BASE_URL__ は deploy.yml の sed コマンドでビルド時に置換される
       location.replace('__VITE_BASE_URL__');
     </script>
   </head>


### PR DESCRIPTION
## 関連 Issue

なし

## 変更概要

<!-- このPRで何を変更したか簡潔に記述してください -->

GitHub Pages は /hit-and-blow-game/ でサービングするが、VITE_BASE_URL が
未設定のため base: '/' でビルドされ、全アセットが 404 になっていた。

## 変更種別

- [x] バグ修正
- [ ] 機能追加
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] その他

## 動作確認

- [ ] ローカルで動作確認済み
- [ ] 既存機能に影響がないことを確認済み

## レビュー観点
