### PR TITLE
[ISSUE 103] パネル選択を好きな順番で入力できるUIに変更

### DIFF
--- a/src/features/game/GameInputArea/GameInputArea.tsx
+++ b/src/features/game/GameInputArea/GameInputArea.tsx
@@ -4,10 +4,11 @@ import { TilePicker } from '@/features/game/TilePicker/TilePicker';
 import { TileChip } from '@/components/TileChip/TileChip';
 
 type GameInputAreaProps = {
-  currentGuess: Tile[];
+  currentGuess: (Tile | null)[];
   answerLength: number;
+  activeSlotIndex: number | null;
   onTileSelect: (tile: Tile) => void;
-  onTileRemove: (index: number) => void;
+  onSlotTap: (index: number) => void;
   onSubmit: () => void;
   onResetGuess: () => void;
   allowDuplicates: boolean;
@@ -16,14 +17,16 @@ type GameInputAreaProps = {
 export function GameInputArea({
   currentGuess,
   answerLength,
+  activeSlotIndex,
   onTileSelect,
-  onTileRemove,
+  onSlotTap,
   onSubmit,
   onResetGuess,
   allowDuplicates,
 }: GameInputAreaProps) {
   const { t } = useTranslation();
-  const canSubmit = currentGuess.length === answerLength;
+  const canSubmit = currentGuess.every((t) => t !== null);
+  const selectedTiles = currentGuess.filter((t): t is Tile => t !== null);
 
   return (
     <div className="mt-6 shrink-0 rounded-xl border-2 border-dashed border-white/30 bg-white/5 p-4">
@@ -34,46 +37,48 @@ export function GameInputArea({
       {/* 入力スロット */}
       <div className="mb-5 flex flex-wrap justify-center gap-2">
         {Array.from({ length: answerLength }, (_, index) => {
-          const tile = currentGuess.at(index);
-
-          if (tile) {
-            return (
-              <button
-                key={index}
-                onClick={() => onTileRemove(index)}
-                className="inline-flex h-14 w-14 cursor-pointer items-center justify-center rounded-2xl overflow-hidden shadow-md transition-all duration-200 hover:-translate-y-0.5 hover:opacity-75 focus-visible:ring-2 focus-visible:ring-indigo-400 focus-visible:ring-offset-2 active:scale-95"
-                aria-label={t('game.removeTile', {
-                  tile: t(`tile.${tile.id}`),
-                })}
-              >
-                <TileChip tileId={tile.id} className="h-full w-full" />
-              </button>
-            );
-          }
+          const tile = currentGuess.at(index) ?? null;
+          const isActive = activeSlotIndex === index;
 
           return (
-            <div
+            <button
               key={index}
-              className="h-14 w-14 rounded-2xl border-2 border-dashed border-white/40 bg-white/5"
-            />
+              onClick={() => onSlotTap(index)}
+              className={`inline-flex h-14 w-14 cursor-pointer items-center justify-center rounded-2xl overflow-hidden shadow-md transition-all duration-200 focus-visible:ring-2 focus-visible:ring-indigo-400 focus-visible:ring-offset-2 active:scale-95 ${
+                isActive
+                  ? 'hab-slot-pulse ring-2 ring-indigo-400'
+                  : ''
+              } ${
+                tile
+                  ? 'hover:-translate-y-0.5 hover:opacity-75'
+                  : 'border-2 border-dashed border-white/40 bg-white/5'
+              }`}
+              aria-label={t('game.selectSlot', { index: index + 1 })}
+            >
+              {tile && (
+                <TileChip tileId={tile.id} className="h-full w-full" />
+              )}
+            </button>
           );
         })}
       </div>
 
       {/* タイルパレット */}
       <TilePicker
-        selected={currentGuess}
+        selected={selectedTiles}
         onSelect={onTileSelect}
         maxLength={answerLength}
         disabled={false}
         allowDuplicates={allowDuplicates}
+        activeSlotIndex={activeSlotIndex}
+        activeSlotTile={activeSlotIndex !== null ? (currentGuess.at(activeSlotIndex) ?? null) : null}
       />
 
       {/* アクションボタン */}
       <div className="mt-5 flex justify-center gap-3">
         <button
           onClick={onResetGuess}
-          disabled={currentGuess.length === 0}
+          disabled={currentGuess.every((t) => t === null)}
           className="rounded-xl border border-white/20 bg-white/10 px-5 py-3 text-white transition-all duration-300 hover:bg-white/20 focus-visible:ring-2 focus-visible:ring-indigo-400 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-40"
         >
           {t('game.reset')}

--- a/src/features/game/TilePicker/TilePicker.tsx
+++ b/src/features/game/TilePicker/TilePicker.tsx
@@ -11,6 +11,8 @@ type TilePickerProps = {
   maxLength: number;
   disabled?: boolean;
   allowDuplicates: boolean;
+  activeSlotIndex: number | null;
+  activeSlotTile: Tile | null;
 };
 
 export const TilePicker = memo(function TilePicker({
@@ -19,6 +21,8 @@ export const TilePicker = memo(function TilePicker({
   maxLength,
   disabled = false,
   allowDuplicates,
+  activeSlotIndex,
+  activeSlotTile,
 }: TilePickerProps) {
   const { t } = useTranslation();
   const containerRef = useRef<HTMLDivElement>(null);
@@ -27,12 +31,26 @@ export const TilePicker = memo(function TilePicker({
   const isTileDisabled = useCallback(
     (tile: Tile): boolean => {
       if (disabled) return true;
+
+      if (activeSlotIndex !== null) {
+        // スロット選択中: 上書きのため maxLength 制限を解除
+        if (!allowDuplicates) {
+          // 選択中スロットのタイルを除外して重複チェック
+          const othersHaveTile = selected.some(
+            (s) => s.id === tile.id && s.id !== activeSlotTile?.id,
+          );
+          if (othersHaveTile) return true;
+        }
+        return false;
+      }
+
+      // スロット未選択時: 現状と同じロジック
       if (selected.length >= maxLength) return true;
       if (!allowDuplicates && selected.some((s) => s.id === tile.id))
         return true;
       return false;
     },
-    [disabled, maxLength, allowDuplicates, selected],
+    [disabled, maxLength, allowDuplicates, selected, activeSlotIndex, activeSlotTile],
   );
 
   const isTileSelected = useCallback(

--- a/src/features/game/useGame.test.ts
+++ b/src/features/game/useGame.test.ts
@@ -8,83 +8,72 @@ describe('useGame', () => {
     // Reset any state between tests
   });
 
-  it('フリープレイ・ノーマルモードで初期化 → 4桁の答えが生成される', () => {
+  it('フリープレイ・ノーマルモードで初期化 → 4桁の答えと全nullスロットが生成される', () => {
     const { result } = renderHook(() => useGame('normal', 'free'));
     expect(result.current.answer).toHaveLength(4);
     expect(result.current.guesses).toHaveLength(0);
-    expect(result.current.currentGuess).toHaveLength(0);
+    expect(result.current.currentGuess).toHaveLength(4);
+    expect(result.current.currentGuess.every((t) => t === null)).toBe(true);
     expect(result.current.isGameOver).toBe(false);
     expect(result.current.isWon).toBe(false);
     expect(result.current.attempts).toBe(0);
     expect(result.current.maxAttempts).toBe(8);
+    expect(result.current.activeSlotIndex).toBeNull();
   });
 
-  it('addTile でタイルが currentGuess に追加される', () => {
+  it('addTile で最初の空きスロットにタイルが設定される', () => {
     const { result } = renderHook(() => useGame('normal', 'free'));
-    const tile = AVAILABLE_TILES[0];
+    const tile = AVAILABLE_TILES.at(0)!;
 
     act(() => {
       result.current.addTile(tile);
     });
 
-    expect(result.current.currentGuess).toHaveLength(1);
-    expect(result.current.currentGuess[0]).toEqual(tile);
+    expect(result.current.currentGuess.at(0)).toEqual(tile);
+    expect(result.current.currentGuess.at(1)).toBeNull();
+    expect(result.current.currentGuess.at(2)).toBeNull();
+    expect(result.current.currentGuess.at(3)).toBeNull();
   });
 
-  it('removeTile で指定位置のタイルが削除される', () => {
-    const { result } = renderHook(() => useGame('normal', 'free'));
-    const tile1 = AVAILABLE_TILES[0];
-    const tile2 = AVAILABLE_TILES[1];
-
-    act(() => {
-      result.current.addTile(tile1);
-      result.current.addTile(tile2);
-    });
-
-    expect(result.current.currentGuess).toHaveLength(2);
-
-    act(() => {
-      result.current.removeTile(0);
-    });
-
-    expect(result.current.currentGuess).toHaveLength(1);
-    expect(result.current.currentGuess[0]).toEqual(tile2);
-  });
-
-  it('resetCurrentGuess で currentGuess が空配列にリセット', () => {
+  it('resetCurrentGuess で全スロットがnullにリセットされる', () => {
     const { result } = renderHook(() => useGame('normal', 'free'));
 
     act(() => {
-      result.current.addTile(AVAILABLE_TILES[0]);
+      result.current.addTile(AVAILABLE_TILES.at(0)!);
     });
 
-    expect(result.current.currentGuess).toHaveLength(1);
+    expect(result.current.currentGuess.at(0)).not.toBeNull();
 
     act(() => {
       result.current.resetCurrentGuess();
     });
 
-    expect(result.current.currentGuess).toHaveLength(0);
+    expect(result.current.currentGuess).toHaveLength(4);
+    expect(result.current.currentGuess.every((t) => t === null)).toBe(true);
+    expect(result.current.activeSlotIndex).toBeNull();
   });
 
   it('allowDuplicates === false のとき、同じタイルの重複追加が拒否される', () => {
     const { result } = renderHook(() => useGame('normal', 'free'));
-    const tile = AVAILABLE_TILES[0];
+    const tile = AVAILABLE_TILES.at(0)!;
 
     act(() => {
       result.current.addTile(tile);
       result.current.addTile(tile);
     });
 
-    expect(result.current.currentGuess).toHaveLength(1);
+    const filledCount = result.current.currentGuess.filter(
+      (t) => t !== null,
+    ).length;
+    expect(filledCount).toBe(1);
   });
 
   it('currentGuess が未完了（桁数不足）で submitGuess → 何も起きない', () => {
     const { result } = renderHook(() => useGame('normal', 'free'));
 
     act(() => {
-      result.current.addTile(AVAILABLE_TILES[0]);
-      result.current.addTile(AVAILABLE_TILES[1]);
+      result.current.addTile(AVAILABLE_TILES.at(0)!);
+      result.current.addTile(AVAILABLE_TILES.at(1)!);
     });
 
     act(() => {
@@ -92,17 +81,20 @@ describe('useGame', () => {
     });
 
     expect(result.current.guesses).toHaveLength(0);
-    expect(result.current.currentGuess).toHaveLength(2);
+    const filledCount = result.current.currentGuess.filter(
+      (t) => t !== null,
+    ).length;
+    expect(filledCount).toBe(2);
   });
 
-  it('タイルを4つ追加して submitGuess → guesses に1件追加される', () => {
+  it('タイルを4つ追加して submitGuess → guesses に1件追加、全スロットnull', () => {
     const { result } = renderHook(() => useGame('normal', 'free'));
 
     act(() => {
-      result.current.addTile(AVAILABLE_TILES[0]);
-      result.current.addTile(AVAILABLE_TILES[1]);
-      result.current.addTile(AVAILABLE_TILES[2]);
-      result.current.addTile(AVAILABLE_TILES[3]);
+      result.current.addTile(AVAILABLE_TILES.at(0)!);
+      result.current.addTile(AVAILABLE_TILES.at(1)!);
+      result.current.addTile(AVAILABLE_TILES.at(2)!);
+      result.current.addTile(AVAILABLE_TILES.at(3)!);
     });
 
     act(() => {
@@ -111,7 +103,9 @@ describe('useGame', () => {
 
     expect(result.current.guesses).toHaveLength(1);
     expect(result.current.attempts).toBe(1);
-    expect(result.current.currentGuess).toHaveLength(0);
+    expect(result.current.currentGuess).toHaveLength(4);
+    expect(result.current.currentGuess.every((t) => t === null)).toBe(true);
+    expect(result.current.activeSlotIndex).toBeNull();
   });
 
   it('resetGame で全状態がリセットされ、新しい答えが生成される', () => {
@@ -119,15 +113,17 @@ describe('useGame', () => {
     const originalAnswer = result.current.answer;
 
     act(() => {
-      result.current.addTile(AVAILABLE_TILES[0]);
+      result.current.addTile(AVAILABLE_TILES.at(0)!);
       result.current.resetGame();
     });
 
     expect(result.current.answer).toHaveLength(4);
     expect(result.current.guesses).toHaveLength(0);
-    expect(result.current.currentGuess).toHaveLength(0);
+    expect(result.current.currentGuess).toHaveLength(4);
+    expect(result.current.currentGuess.every((t) => t === null)).toBe(true);
     expect(result.current.isGameOver).toBe(false);
     expect(result.current.isWon).toBe(false);
+    expect(result.current.activeSlotIndex).toBeNull();
     // 乱数生成なので異なる答えが生成される確率が高い
     expect(result.current.answer).not.toEqual(originalAnswer);
   });
@@ -188,5 +184,175 @@ describe('useGame', () => {
     expect(result.current.isGameOver).toBe(true);
     expect(result.current.isWon).toBe(false);
     expect(result.current.guesses).toHaveLength(6);
+  });
+
+  // --- handleSlotTap テスト ---
+
+  it('handleSlotTap でスロットが選択中になる', () => {
+    const { result } = renderHook(() => useGame('normal', 'free'));
+
+    act(() => {
+      result.current.handleSlotTap(1);
+    });
+
+    expect(result.current.activeSlotIndex).toBe(1);
+  });
+
+  it('handleSlotTap で同じスロットを再タップ → 選択解除', () => {
+    const { result } = renderHook(() => useGame('normal', 'free'));
+
+    act(() => {
+      result.current.handleSlotTap(1);
+    });
+
+    expect(result.current.activeSlotIndex).toBe(1);
+
+    act(() => {
+      result.current.handleSlotTap(1);
+    });
+
+    expect(result.current.activeSlotIndex).toBeNull();
+  });
+
+  it('handleSlotTap で異なるスロットをタップ → スワップ', () => {
+    const { result } = renderHook(() => useGame('normal', 'free'));
+    const tile0 = AVAILABLE_TILES.at(0)!;
+    const tile1 = AVAILABLE_TILES.at(1)!;
+
+    act(() => {
+      result.current.addTile(tile0);
+      result.current.addTile(tile1);
+    });
+
+    // スロット0: tile0, スロット1: tile1
+    expect(result.current.currentGuess.at(0)).toEqual(tile0);
+    expect(result.current.currentGuess.at(1)).toEqual(tile1);
+
+    // スロット0を選択 → スロット1をタップ → スワップ
+    act(() => {
+      result.current.handleSlotTap(0);
+    });
+
+    act(() => {
+      result.current.handleSlotTap(1);
+    });
+
+    expect(result.current.currentGuess.at(0)).toEqual(tile1);
+    expect(result.current.currentGuess.at(1)).toEqual(tile0);
+    expect(result.current.activeSlotIndex).toBeNull();
+  });
+
+  it('activeSlotIndex 指定時に addTile → 選択中スロットに上書き', () => {
+    const { result } = renderHook(() => useGame('normal', 'free'));
+    const tile0 = AVAILABLE_TILES.at(0)!;
+    const tile1 = AVAILABLE_TILES.at(1)!;
+
+    act(() => {
+      result.current.addTile(tile0);
+    });
+
+    // スロット0を選択
+    act(() => {
+      result.current.handleSlotTap(0);
+    });
+
+    expect(result.current.activeSlotIndex).toBe(0);
+
+    // 別タイルで上書き
+    act(() => {
+      result.current.addTile(tile1);
+    });
+
+    expect(result.current.currentGuess.at(0)).toEqual(tile1);
+    expect(result.current.activeSlotIndex).toBeNull();
+  });
+
+  it('addTile 上書き時の重複チェック（上書き対象を除外）', () => {
+    const { result } = renderHook(() => useGame('normal', 'free'));
+    const tile0 = AVAILABLE_TILES.at(0)!;
+    const tile1 = AVAILABLE_TILES.at(1)!;
+
+    act(() => {
+      result.current.addTile(tile0);
+      result.current.addTile(tile1);
+    });
+
+    // スロット0(tile0)を選択し、tile0で上書き → 自分自身なので許可
+    act(() => {
+      result.current.handleSlotTap(0);
+    });
+
+    act(() => {
+      result.current.addTile(tile0);
+    });
+
+    expect(result.current.currentGuess.at(0)).toEqual(tile0);
+
+    // スロット0(tile0)を選択し、tile1で上書き → スロット1に既にtile1がある → 拒否
+    act(() => {
+      result.current.handleSlotTap(0);
+    });
+
+    act(() => {
+      result.current.addTile(tile1);
+    });
+
+    // tile1はスロット1に既にあるため上書き拒否、tile0のまま
+    expect(result.current.currentGuess.at(0)).toEqual(tile0);
+  });
+
+  it('リセット時に activeSlotIndex が null になる', () => {
+    const { result } = renderHook(() => useGame('normal', 'free'));
+
+    act(() => {
+      result.current.addTile(AVAILABLE_TILES.at(0)!);
+      result.current.handleSlotTap(0);
+    });
+
+    expect(result.current.activeSlotIndex).toBe(0);
+
+    act(() => {
+      result.current.resetCurrentGuess();
+    });
+
+    expect(result.current.activeSlotIndex).toBeNull();
+  });
+
+  it('提出時に activeSlotIndex が null になる', () => {
+    const { result } = renderHook(() => useGame('normal', 'free'));
+    const answer = result.current.answer;
+
+    act(() => {
+      answer.forEach((tile) => result.current.addTile(tile));
+    });
+
+    act(() => {
+      result.current.handleSlotTap(0);
+    });
+
+    expect(result.current.activeSlotIndex).toBe(0);
+
+    act(() => {
+      result.current.submitGuess();
+    });
+
+    expect(result.current.activeSlotIndex).toBeNull();
+  });
+
+  it('空スロット同士のスワップ', () => {
+    const { result } = renderHook(() => useGame('normal', 'free'));
+
+    // 全スロット空の状態でスワップ
+    act(() => {
+      result.current.handleSlotTap(0);
+    });
+
+    act(() => {
+      result.current.handleSlotTap(2);
+    });
+
+    // 空同士のスワップは正常に完了（全てnullのまま）
+    expect(result.current.currentGuess.every((t) => t === null)).toBe(true);
+    expect(result.current.activeSlotIndex).toBeNull();
   });
 });

--- a/src/features/game/useGame.ts
+++ b/src/features/game/useGame.ts
@@ -7,17 +7,21 @@ import { getDailySeed } from '@/utils/randomGenerator';
 type UseGameReturn = {
   answer: Tile[];
   guesses: Guess[];
-  currentGuess: Tile[];
+  currentGuess: (Tile | null)[];
   isGameOver: boolean;
   isWon: boolean;
   attempts: number;
   maxAttempts: number;
+  activeSlotIndex: number | null;
   submitGuess: () => void;
   addTile: (tile: Tile) => void;
-  removeTile: (index: number) => void;
+  handleSlotTap: (index: number) => void;
   resetCurrentGuess: () => void;
   resetGame: () => void;
 };
+
+const createEmptySlots = (length: number): (Tile | null)[] =>
+  Array.from({ length }, () => null);
 
 export const useGame = (mode: GameMode, playType: PlayType): UseGameReturn => {
   // デイリーチャレンジはノーマルモード固定
@@ -34,7 +38,10 @@ export const useGame = (mode: GameMode, playType: PlayType): UseGameReturn => {
   const [prevMode, setPrevMode] = useState<GameMode>(effectiveMode);
   const [answer, setAnswer] = useState<Tile[]>(() => createInitialAnswer());
   const [guesses, setGuesses] = useState<Guess[]>([]);
-  const [currentGuess, setCurrentGuess] = useState<Tile[]>([]);
+  const [currentGuess, setCurrentGuess] = useState<(Tile | null)[]>(() =>
+    createEmptySlots(length),
+  );
+  const [activeSlotIndex, setActiveSlotIndex] = useState<number | null>(null);
   const [isGameOver, setIsGameOver] = useState(false);
   const [isWon, setIsWon] = useState(false);
 
@@ -43,7 +50,8 @@ export const useGame = (mode: GameMode, playType: PlayType): UseGameReturn => {
     setPrevMode(effectiveMode);
     setAnswer(generateAnswer(length, allowDuplicates));
     setGuesses([]);
-    setCurrentGuess([]);
+    setCurrentGuess(createEmptySlots(length));
+    setActiveSlotIndex(null);
     setIsGameOver(false);
     setIsWon(false);
   }
@@ -51,30 +59,70 @@ export const useGame = (mode: GameMode, playType: PlayType): UseGameReturn => {
   const addTile = useCallback(
     (tile: Tile): void => {
       setCurrentGuess((prev) => {
-        if (prev.length >= length) return prev;
-        if (!allowDuplicates && prev.some((t) => t.id === tile.id)) {
+        if (activeSlotIndex !== null) {
+          // スロット選択中 → 選択中スロットに上書き
+          const existingTile = prev.at(activeSlotIndex);
+          if (
+            !allowDuplicates &&
+            prev.some(
+              (t, i) =>
+                t !== null &&
+                t.id === tile.id &&
+                i !== activeSlotIndex &&
+                existingTile?.id !== tile.id,
+            )
+          ) {
+            return prev;
+          }
+          return prev.map((t, i) => (i === activeSlotIndex ? tile : t));
+        }
+
+        // スロット未選択 → 最初の空きスロットに設定
+        const emptyIndex = prev.indexOf(null);
+        if (emptyIndex === -1) return prev;
+        if (!allowDuplicates && prev.some((t) => t !== null && t.id === tile.id)) {
           return prev;
         }
-        return [...prev, tile];
+        return prev.map((t, i) => (i === emptyIndex ? tile : t));
       });
+      setActiveSlotIndex(null);
     },
-    [length, allowDuplicates],
+    [activeSlotIndex, allowDuplicates],
   );
 
-  const removeTile = useCallback((index: number): void => {
-    setCurrentGuess((prev) => prev.filter((_, i) => i !== index));
-  }, []);
+  const handleSlotTap = useCallback(
+    (index: number): void => {
+      if (activeSlotIndex === null) {
+        setActiveSlotIndex(index);
+      } else if (activeSlotIndex === index) {
+        setActiveSlotIndex(null);
+      } else {
+        // スワップ
+        setCurrentGuess((prev) =>
+          prev.map((t, i) => {
+            if (i === activeSlotIndex) return prev.at(index) ?? null;
+            if (i === index) return prev.at(activeSlotIndex) ?? null;
+            return t;
+          }),
+        );
+        setActiveSlotIndex(null);
+      }
+    },
+    [activeSlotIndex],
+  );
 
   const resetCurrentGuess = useCallback((): void => {
-    setCurrentGuess([]);
-  }, []);
+    setCurrentGuess(createEmptySlots(length));
+    setActiveSlotIndex(null);
+  }, [length]);
 
   const submitGuess = useCallback((): void => {
-    if (currentGuess.length !== length) return;
+    if (!currentGuess.every((t) => t !== null)) return;
 
-    const { hits, blows } = checkGuess(currentGuess, answer);
+    const validGuess = currentGuess.filter((t): t is Tile => t !== null);
+    const { hits, blows } = checkGuess(validGuess, answer);
     const newGuess: Guess = {
-      tiles: currentGuess,
+      tiles: validGuess,
       hits,
       blows,
       timestamp: Date.now(),
@@ -82,7 +130,8 @@ export const useGame = (mode: GameMode, playType: PlayType): UseGameReturn => {
 
     const newGuesses = [...guesses, newGuess];
     setGuesses(newGuesses);
-    setCurrentGuess([]);
+    setCurrentGuess(createEmptySlots(length));
+    setActiveSlotIndex(null);
 
     const { isFinished, isWon: won } = isGameFinished(
       newGuesses,
@@ -98,10 +147,11 @@ export const useGame = (mode: GameMode, playType: PlayType): UseGameReturn => {
   const resetGame = useCallback((): void => {
     setAnswer(createInitialAnswer());
     setGuesses([]);
-    setCurrentGuess([]);
+    setCurrentGuess(createEmptySlots(length));
+    setActiveSlotIndex(null);
     setIsGameOver(false);
     setIsWon(false);
-  }, [createInitialAnswer]);
+  }, [createInitialAnswer, length]);
 
   return {
     answer,
@@ -111,9 +161,10 @@ export const useGame = (mode: GameMode, playType: PlayType): UseGameReturn => {
     isWon,
     attempts: guesses.length,
     maxAttempts,
+    activeSlotIndex,
     submitGuess,
     addTile,
-    removeTile,
+    handleSlotTap,
     resetCurrentGuess,
     resetGame,
   };

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -28,7 +28,7 @@
     "dailyTitle": "📅 Daily ({{mode}})",
     "freeTitle": "Free Play ({{mode}})",
     "currentGuessLabel": "Current Input",
-    "removeTile": "Remove {{tile}}",
+    "selectSlot": "Select slot {{index}}",
     "infoModeLabel": "Mode",
     "infoDigitsLabel": "Digits",
     "infoDuplicatesLabel": "Dup",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -28,7 +28,7 @@
     "dailyTitle": "📅 今日の問題（{{mode}}）",
     "freeTitle": "フリープレイ（{{mode}}）",
     "currentGuessLabel": "今の入力",
-    "removeTile": "{{tile}}を削除",
+    "selectSlot": "スロット{{index}}を選択",
     "infoModeLabel": "モード",
     "infoDigitsLabel": "桁数",
     "infoDuplicatesLabel": "重複",

--- a/src/pages/DailyGamePage/DailyGamePage.tsx
+++ b/src/pages/DailyGamePage/DailyGamePage.tsx
@@ -36,7 +36,8 @@ export default function DailyGamePage() {
     maxAttempts,
     submitGuess,
     addTile,
-    removeTile,
+    handleSlotTap,
+    activeSlotIndex,
     resetCurrentGuess,
     resetGame,
   } = useGame(DAILY_MODE, PLAY_TYPE_IDS.DAILY);
@@ -152,8 +153,9 @@ export default function DailyGamePage() {
               <GameInputArea
                 currentGuess={currentGuess}
                 answerLength={modeConfig.length}
+                activeSlotIndex={activeSlotIndex}
                 onTileSelect={addTile}
-                onTileRemove={removeTile}
+                onSlotTap={handleSlotTap}
                 onSubmit={submitGuess}
                 onResetGuess={resetCurrentGuess}
                 allowDuplicates={modeConfig.allowDuplicates}

--- a/src/pages/FreeGamePage/FreeGamePage.tsx
+++ b/src/pages/FreeGamePage/FreeGamePage.tsx
@@ -37,7 +37,8 @@ export default function FreeGamePage() {
     maxAttempts,
     submitGuess,
     addTile,
-    removeTile,
+    handleSlotTap,
+    activeSlotIndex,
     resetCurrentGuess,
     resetGame,
   } = useGame(mode, PLAY_TYPE_IDS.FREE);
@@ -104,8 +105,9 @@ export default function FreeGamePage() {
               <GameInputArea
                 currentGuess={currentGuess}
                 answerLength={modeConfig.length}
+                activeSlotIndex={activeSlotIndex}
                 onTileSelect={addTile}
-                onTileRemove={removeTile}
+                onSlotTap={handleSlotTap}
                 onSubmit={submitGuess}
                 onResetGuess={resetCurrentGuess}
                 allowDuplicates={modeConfig.allowDuplicates}

--- a/src/pages/TutorialPage/TutorialPage.tsx
+++ b/src/pages/TutorialPage/TutorialPage.tsx
@@ -37,7 +37,8 @@ export default function TutorialPage() {
     maxAttempts,
     submitGuess,
     addTile,
-    removeTile,
+    handleSlotTap,
+    activeSlotIndex,
     resetCurrentGuess,
   } = useGame(GAME_MODE_IDS.BEGINNER, PLAY_TYPE_IDS.FREE);
 
@@ -204,8 +205,9 @@ export default function TutorialPage() {
             <GameInputArea
               currentGuess={currentGuess}
               answerLength={modeConfig.length}
+              activeSlotIndex={activeSlotIndex}
               onTileSelect={addTile}
-              onTileRemove={removeTile}
+              onSlotTap={handleSlotTap}
               onSubmit={submitGuess}
               onResetGuess={resetCurrentGuess}
               allowDuplicates={modeConfig.allowDuplicates}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -31,6 +31,17 @@
   }
 }
 
+@keyframes slotPulse {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(129, 140, 248, 0.6); }
+  50%      { box-shadow: 0 0 0 8px rgba(129, 140, 248, 0); }
+}
+
+@layer utilities {
+  .hab-slot-pulse {
+    animation: slotPulse 1.5s ease-in-out infinite;
+  }
+}
+
 @keyframes tileBounce {
   0%   { transform: scale(1); }
   30%  { transform: scale(0.9); }


### PR DESCRIPTION
## 関連 Issue

closes #103

## 変更概要

スロットタップで選択→タイル選択で上書き、別スロットタップでスワップという操作フローに変更することで、好きな位置に直接入力できるUIを実現した。4桁以上モードでのタイル並べ替え操作の煩雑さを解消。

### 実装内容

| 変更ファイル | 内容 |
|---|---|
| `src/styles/index.css` | `hab-slot-pulse` パルスアニメーション追加 |
| `src/features/game/useGame.ts` | currentGuess型変更（可変長→固定長null配列）、activeSlotIndex追加、handleSlotTap/swapSlots追加、removeTile廃止 |
| `src/features/game/GameInputArea/GameInputArea.tsx` | 全スロットをbutton統一、パルス+ハイライト表示、props変更 |
| `src/features/game/TilePicker/TilePicker.tsx` | activeSlotIndex対応、スロット選択中の重複チェック変更 |
| `src/pages/FreeGamePage/DailyGamePage/TutorialPage.tsx` | props接続更新 |
| `src/i18n/locales/ja.json` / `en.json` | i18nテキスト更新 |
| `src/features/game/useGame.test.ts` | テスト19件全パス（新規8件追加） |

## 変更種別

- [x] 機能追加

## 動作確認

- [x] ローカルで動作確認済み
- [x] 既存機能に影響がないことを確認済み
  - `pnpm test` → 93テスト全パス
  - `pnpm lint` → エラー0
  - `pnpm build` → 成功

## レビュー観点

- スロット選択時のパルスアニメーション表示確認
- スロット同士のスワップ動作確認
- 重複不可モードでの上書き時重複チェック
- 全モード（BEGINNER〜MASTER）での動作確認