### PR TITLE
[ISSUE 116] エキスパートモード時の入力欄が折り返すのを修正

### DIFF
--- a/.claude/plans/issue-116-input-slot-responsive.md
+++ b/.claude/plans/issue-116-input-slot-responsive.md
@@ -1,0 +1,137 @@
+# Issue #116: エキスパートモード時の入力欄が画面幅によって折り返す
+
+## 概要
+
+小画面端末（iPhone SE: 375px）でエキスパート・マスターモード（6桁）の入力スロットが折り返して表示され、視認性が悪い。
+
+**意図（なぜ必要か）**: 6桁モードでの入力体験を改善する。パッと見で全スロットが一行に並んでいないと直感的に把握しづらい。
+
+**選択理由**: スロットサイズを小画面時に縮小するアプローチを採用。`flex-wrap` を `flex-nowrap` に変更し、タイルサイズをレスポンシブ化する。gap を固定ピクセルからレスポンシブに変えることで、画面幅に応じた最適なサイズに調整できる。
+
+代替案として `@container` クエリや桁数に応じた動的クラスも考えたが、既存の `sm:` ブレークポイントパターンに揃えるのが最もシンプル。
+
+---
+
+## 計算根拠
+
+iPhone SE (375px) の利用可能幅: 375 - 32 (px-4 × 2) - 16 (p-4 × 2: InputAreaの内側padding) = 327px
+
+### 現状（折り返し発生）
+
+- 6 × 56px(h-14) + 5 × 8px(gap-2) = **376px** > 327px
+
+### 修正後（収まる）
+
+- 6 × 44px(h-11) + 5 × 6px(gap-1.5) = **294px** < 327px
+- sm(640px)以上: 6 × 56px(h-14) + 5 × 8px(gap-2) = **376px** （余裕あり）
+
+---
+
+## 変更ファイル
+
+| ファイル                                            | 変更内容                                             |
+| --------------------------------------------------- | ---------------------------------------------------- |
+| `src/features/game/GameInputArea/GameInputArea.tsx` | 入力スロットをレスポンシブサイズ化、flex-nowrap      |
+| `src/features/game/TilePicker/TilePicker.tsx`       | タイルパレットのサイズをレスポンシブ化（一貫性確保） |
+| `src/features/game/ResultDisplay/ResultDisplay.tsx` | 結果画面の正解表示もレスポンシブ化                   |
+
+---
+
+## タスク
+
+### Task 1: 入力スロットのレスポンシブ対応
+
+#### 受け入れ条件
+
+- [ ] 6桁モードで375px幅でも入力スロットが折り返さない
+- [ ] 3〜4桁モードの表示が崩れない
+
+#### 実装詳細
+
+**`src/features/game/GameInputArea/GameInputArea.tsx`**
+
+行38: コンテナのクラスを変更
+
+```diff
+- <div className="mb-5 flex flex-wrap justify-center gap-2">
++ <div className="mb-5 flex flex-nowrap justify-center gap-1.5 sm:gap-2">
+```
+
+行47: スロットボタンのサイズをレスポンシブ化
+
+```diff
+- className={`inline-flex h-14 w-14 cursor-pointer ...
++ className={`inline-flex h-11 w-11 sm:h-14 sm:w-14 cursor-pointer ...
+```
+
+### Task 2: タイルパレットのレスポンシブ対応
+
+#### 受け入れ条件
+
+- [ ] タイルパレットが小画面で崩れない
+- [ ] スロットとタイルのサイズ感に一貫性がある
+
+#### 実装詳細
+
+**`src/features/game/TilePicker/TilePicker.tsx`**
+
+行87: gap は既に sm 対応済み（`gap-3 sm:gap-4`）、変更不要。
+
+行102: タイルサイズを調整（現在 `h-14 w-14 ... sm:h-16 sm:w-16`）
+→ 小画面サイズを `h-11 w-11` に変更して入力スロットと揃える。
+
+```diff
+- className={`inline-flex h-14 w-14 items-center justify-center rounded-2xl overflow-hidden shadow-md ... sm:h-16 sm:w-16
++ className={`inline-flex h-11 w-11 items-center justify-center rounded-2xl overflow-hidden shadow-md ... sm:h-14 sm:w-14
+```
+
+行109: アイコンサイズも調整
+
+```diff
+- <TileIcon tileId={tile.id} className="h-8 w-8 sm:h-9 sm:w-9" />
++ <TileIcon tileId={tile.id} className="h-6 w-6 sm:h-8 sm:w-8" />
+```
+
+タイルパレットの計算:
+
+- 小画面: 4 × 44px + 3 × 12px = **212px** （余裕あり）
+- sm以上: 4 × 56px + 3 × 16px = **272px** （余裕あり）
+
+### Task 3: 結果画面の正解表示レスポンシブ対応
+
+#### 受け入れ条件
+
+- [ ] 結果画面の正解タイル表示が6桁でも折り返さない
+
+#### 実装詳細
+
+**`src/features/game/ResultDisplay/ResultDisplay.tsx`**
+
+行83: コンテナ
+
+```diff
+- <div className="flex flex-wrap justify-center gap-2">
++ <div className="flex flex-nowrap justify-center gap-1.5 sm:gap-2">
+```
+
+行88: タイルサイズ
+
+```diff
+- className="h-14 w-14 rounded-2xl shadow-md"
++ className="h-11 w-11 sm:h-14 sm:w-14 rounded-2xl shadow-md"
+```
+
+---
+
+## 受け入れ条件
+
+- [ ] iPhone SE (375px) でエキスパート・マスターモード（6桁）の入力スロットが折り返さない
+- [ ] 結果画面の正解表示も同様に折り返さない
+- [ ] ビギナー〜ハードモード（3〜4桁）の表示が崩れない
+- [ ] sm(640px)以上の表示に変化がない（もしくは改善のみ）
+- [ ] `pnpm type-check` が通る
+- [ ] `pnpm lint` が通る
+
+## 注意事項
+
+- TutorialPageの `h-14 w-14`（行126）はグリッド内の説明用表示で桁数問題に影響しないため対象外

--- a/src/features/game/GameInputArea/GameInputArea.tsx
+++ b/src/features/game/GameInputArea/GameInputArea.tsx
@@ -35,7 +35,7 @@ export function GameInputArea({
       </p>
 
       {/* 入力スロット */}
-      <div className="mb-5 flex flex-wrap justify-center gap-2">
+      <div className="mb-5 flex flex-nowrap justify-center gap-1.5 sm:gap-2">
         {Array.from({ length: answerLength }, (_, index) => {
           const tile = currentGuess.at(index) ?? null;
           const isActive = activeSlotIndex === index;
@@ -44,10 +44,8 @@ export function GameInputArea({
             <button
               key={index}
               onClick={() => onSlotTap(index)}
-              className={`inline-flex h-14 w-14 cursor-pointer items-center justify-center rounded-2xl overflow-hidden shadow-md transition-all duration-200 focus-visible:ring-2 focus-visible:ring-indigo-400 focus-visible:ring-offset-2 active:scale-95 ${
-                isActive
-                  ? 'hab-slot-pulse ring-2 ring-indigo-400'
-                  : ''
+              className={`inline-flex h-11 w-11 cursor-pointer items-center justify-center overflow-hidden rounded-2xl shadow-md transition-all duration-200 focus-visible:ring-2 focus-visible:ring-indigo-400 focus-visible:ring-offset-2 active:scale-95 sm:h-14 sm:w-14 ${
+                isActive ? 'hab-slot-pulse ring-2 ring-indigo-400' : ''
               } ${
                 tile
                   ? 'hover:-translate-y-0.5 hover:opacity-75'
@@ -55,9 +53,7 @@ export function GameInputArea({
               }`}
               aria-label={t('game.selectSlot', { index: index + 1 })}
             >
-              {tile && (
-                <TileChip tileId={tile.id} className="h-full w-full" />
-              )}
+              {tile && <TileChip tileId={tile.id} className="h-full w-full" />}
             </button>
           );
         })}
@@ -71,7 +67,11 @@ export function GameInputArea({
         disabled={false}
         allowDuplicates={allowDuplicates}
         activeSlotIndex={activeSlotIndex}
-        activeSlotTile={activeSlotIndex !== null ? (currentGuess.at(activeSlotIndex) ?? null) : null}
+        activeSlotTile={
+          activeSlotIndex !== null
+            ? (currentGuess.at(activeSlotIndex) ?? null)
+            : null
+        }
       />
 
       {/* アクションボタン */}

--- a/src/features/game/GameInputArea/GameInputArea.tsx
+++ b/src/features/game/GameInputArea/GameInputArea.tsx
@@ -44,7 +44,7 @@ export function GameInputArea({
             <button
               key={index}
               onClick={() => onSlotTap(index)}
-              className={`inline-flex h-11 w-11 cursor-pointer items-center justify-center overflow-hidden rounded-2xl shadow-md transition-all duration-200 focus-visible:ring-2 focus-visible:ring-indigo-400 focus-visible:ring-offset-2 active:scale-95 sm:h-14 sm:w-14 ${
+              className={`inline-flex h-11 w-11 cursor-pointer items-center justify-center overflow-hidden rounded-xl shadow-md transition-all duration-200 focus-visible:ring-2 focus-visible:ring-indigo-400 focus-visible:ring-offset-2 active:scale-95 sm:h-14 sm:w-14 sm:rounded-2xl ${
                 isActive ? 'hab-slot-pulse ring-2 ring-indigo-400' : ''
               } ${
                 tile

--- a/src/features/game/ResultDisplay/ResultDisplay.tsx
+++ b/src/features/game/ResultDisplay/ResultDisplay.tsx
@@ -85,7 +85,7 @@ export function ResultDisplay({
             <TileChip
               key={index}
               tileId={tile.id}
-              className="h-11 w-11 rounded-2xl shadow-md sm:h-14 sm:w-14"
+              className="h-11 w-11 rounded-xl shadow-md sm:h-14 sm:w-14 sm:rounded-2xl"
             />
           ))}
         </div>

--- a/src/features/game/ResultDisplay/ResultDisplay.tsx
+++ b/src/features/game/ResultDisplay/ResultDisplay.tsx
@@ -80,12 +80,12 @@ export function ResultDisplay({
         <p className="mb-3 text-sm text-white/60">
           {isWon ? t('result.correct') : t('result.answer')}
         </p>
-        <div className="flex flex-wrap justify-center gap-2">
+        <div className="flex flex-nowrap justify-center gap-1.5 sm:gap-2">
           {answer.map((tile, index) => (
             <TileChip
               key={index}
               tileId={tile.id}
-              className="h-14 w-14 rounded-2xl shadow-md"
+              className="h-11 w-11 rounded-2xl shadow-md sm:h-14 sm:w-14"
             />
           ))}
         </div>

--- a/src/features/game/TilePicker/TilePicker.tsx
+++ b/src/features/game/TilePicker/TilePicker.tsx
@@ -91,7 +91,10 @@ export const TilePicker = memo(function TilePicker({
   );
 
   return (
-    <div ref={containerRef} className="grid grid-cols-4 gap-3 sm:gap-4">
+    <div
+      ref={containerRef}
+      className="grid grid-cols-4 justify-items-center gap-3 sm:gap-4"
+    >
       {AVAILABLE_TILES.map((tile, index) => {
         const tileDisabled = isTileDisabled(tile);
         const tileSelected = isTileSelected(tile);

--- a/src/features/game/TilePicker/TilePicker.tsx
+++ b/src/features/game/TilePicker/TilePicker.tsx
@@ -50,7 +50,14 @@ export const TilePicker = memo(function TilePicker({
         return true;
       return false;
     },
-    [disabled, maxLength, allowDuplicates, selected, activeSlotIndex, activeSlotTile],
+    [
+      disabled,
+      maxLength,
+      allowDuplicates,
+      selected,
+      activeSlotIndex,
+      activeSlotTile,
+    ],
   );
 
   const isTileSelected = useCallback(
@@ -99,14 +106,14 @@ export const TilePicker = memo(function TilePicker({
             onClick={() => handleSelect(tile)}
             onKeyDown={(e) => handleKeyDown(e, index)}
             onAnimationEnd={() => setAnimatingTileId(null)}
-            className={`inline-flex h-14 w-14 items-center justify-center rounded-2xl overflow-hidden shadow-md transition-all duration-300 focus-visible:ring-2 focus-visible:ring-indigo-400 focus-visible:ring-offset-2 sm:h-16 sm:w-16 ${
+            className={`inline-flex h-11 w-11 items-center justify-center overflow-hidden rounded-2xl shadow-md transition-all duration-300 focus-visible:ring-2 focus-visible:ring-indigo-400 focus-visible:ring-offset-2 sm:h-14 sm:w-14 ${
               tileDisabled
                 ? 'cursor-not-allowed bg-gray-600 text-gray-400 opacity-30'
                 : 'cursor-pointer hover:-translate-y-1 hover:scale-105 hover:shadow-lg active:scale-95'
             } ${tileSelected ? 'ring-4 ring-white/60' : ''} ${animatingTileId === tile.id ? 'hab-tile-bounce' : ''}`}
           >
             {tileDisabled ? (
-              <TileIcon tileId={tile.id} className="h-8 w-8 sm:h-9 sm:w-9" />
+              <TileIcon tileId={tile.id} className="h-6 w-6 sm:h-8 sm:w-8" />
             ) : (
               <TileChip tileId={tile.id} className="h-full w-full" />
             )}

--- a/src/features/game/TilePicker/TilePicker.tsx
+++ b/src/features/game/TilePicker/TilePicker.tsx
@@ -106,7 +106,7 @@ export const TilePicker = memo(function TilePicker({
             onClick={() => handleSelect(tile)}
             onKeyDown={(e) => handleKeyDown(e, index)}
             onAnimationEnd={() => setAnimatingTileId(null)}
-            className={`inline-flex h-11 w-11 items-center justify-center overflow-hidden rounded-2xl shadow-md transition-all duration-300 focus-visible:ring-2 focus-visible:ring-indigo-400 focus-visible:ring-offset-2 sm:h-14 sm:w-14 ${
+            className={`inline-flex h-11 w-11 items-center justify-center overflow-hidden rounded-xl shadow-md transition-all duration-300 focus-visible:ring-2 focus-visible:ring-indigo-400 focus-visible:ring-offset-2 sm:h-14 sm:w-14 sm:rounded-2xl ${
               tileDisabled
                 ? 'cursor-not-allowed bg-gray-600 text-gray-400 opacity-30'
                 : 'cursor-pointer hover:-translate-y-1 hover:scale-105 hover:shadow-lg active:scale-95'


### PR DESCRIPTION
## 関連 Issue

closes #116

## 変更概要

iPhone SE (375px) でエキスパート・マスターモード（6桁）の入力スロットが折り返して表示される問題を修正。

- 入力スロット・タイルパレット・結果表示の正解タイルをレスポンシブ化
- `flex-nowrap` で一行表示を保証
- 小画面時（< 640px）: `h-11 w-11` + `gap-1.5` + `rounded-xl`
- sm以上（≥ 640px）: `h-14 w-14` + `gap-2` + `rounded-2xl`（従来通り）

## 変更種別

- [x] バグ修正

## 動作確認

- [ ] ローカルで動作確認済み
- [ ] 既存機能に影響がないことを確認済み

## レビュー観点

- 375px幅での6桁モードで入力スロットが一行に収まるか（計算上: 6×44 + 5×6 = 294px < 327px）
- 3〜4桁モードの表示が崩れていないか
- sm以上の表示が変化していないか